### PR TITLE
feat: Use strum ✨

### DIFF
--- a/ratatui-counter/Cargo.toml
+++ b/ratatui-counter/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 signal-hook = "0.3.17"
 strip-ansi-escapes = "0.2.0"
+strum = { version = "0.25.0", features = ["derive"] }
 tokio = { version = "1.32.0", features = ["full"] }
 tokio-util = "0.7.9"
 tracing = "0.1.37"

--- a/ratatui-counter/src/action.rs
+++ b/ratatui-counter/src/action.rs
@@ -1,12 +1,13 @@
-use std::fmt;
+use std::{fmt, string::ToString};
 
 use serde::{
   de::{self, Deserializer, Visitor},
   Deserialize, Serialize,
 };
+use strum::Display;
 
 //// ANCHOR: action_enum
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Display, Deserialize)]
 pub enum Action {
   Tick,
   Render,
@@ -30,57 +31,3 @@ pub enum Action {
   Update,
 }
 //// ANCHOR_END: action_enum
-
-impl<'de> Deserialize<'de> for Action {
-  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-  where
-    D: Deserializer<'de>,
-  {
-    struct ActionVisitor;
-
-    impl<'de> Visitor<'de> for ActionVisitor {
-      type Value = Action;
-
-      fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("a valid string representation of Action")
-      }
-
-      fn visit_str<E>(self, value: &str) -> Result<Action, E>
-      where
-        E: de::Error,
-      {
-        match value {
-          "Tick" => Ok(Action::Tick),
-          "Render" => Ok(Action::Render),
-          "Suspend" => Ok(Action::Suspend),
-          "Resume" => Ok(Action::Resume),
-          "Quit" => Ok(Action::Quit),
-          "Refresh" => Ok(Action::Refresh),
-          "Help" => Ok(Action::Help),
-          "ScheduleIncrement" => Ok(Action::ScheduleIncrement),
-          "ScheduleDecrement" => Ok(Action::ScheduleDecrement),
-          "ToggleShowHelp" => Ok(Action::ToggleShowHelp),
-          "EnterInsert" => Ok(Action::EnterInsert),
-          "EnterNormal" => Ok(Action::EnterNormal),
-          data if data.starts_with("Error(") => {
-            let error_msg = data.trim_start_matches("Error(").trim_end_matches(")");
-            Ok(Action::Error(error_msg.to_string()))
-          },
-          data if data.starts_with("Resize(") => {
-            let parts: Vec<&str> = data.trim_start_matches("Resize(").trim_end_matches(")").split(',').collect();
-            if parts.len() == 2 {
-              let width: u16 = parts[0].trim().parse().map_err(E::custom)?;
-              let height: u16 = parts[1].trim().parse().map_err(E::custom)?;
-              Ok(Action::Resize(width, height))
-            } else {
-              Err(E::custom(format!("Invalid Resize format: {}", value)))
-            }
-          },
-          _ => Err(E::custom(format!("Unknown Action variant: {}", value))),
-        }
-      }
-    }
-
-    deserializer.deserialize_str(ActionVisitor)
-  }
-}

--- a/template/Cargo.toml
+++ b/template/Cargo.toml
@@ -28,6 +28,7 @@ serde = { version = "1.0.188", features = ["derive"] }
 serde_json = "1.0.107"
 signal-hook = "0.3.17"
 strip-ansi-escapes = "0.2.0"
+strum = { version = "0.25.0", features = ["derive"] }
 tokio = { version = "1.32.0", features = ["full"] }
 tokio-util = "0.7.9"
 tracing = "0.1.37"

--- a/template/src/action.rs
+++ b/template/src/action.rs
@@ -1,11 +1,12 @@
-use std::fmt;
+use std::{fmt, string::ToString};
 
 use serde::{
   de::{self, Deserializer, Visitor},
   Deserialize, Serialize,
 };
+use strum::Display;
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Display, Deserialize)]
 pub enum Action {
   Tick,
   Render,
@@ -16,53 +17,4 @@ pub enum Action {
   Refresh,
   Error(String),
   Help,
-}
-
-impl<'de> Deserialize<'de> for Action {
-  fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-  where
-    D: Deserializer<'de>,
-  {
-    struct ActionVisitor;
-
-    impl<'de> Visitor<'de> for ActionVisitor {
-      type Value = Action;
-
-      fn expecting(&self, formatter: &mut fmt::Formatter) -> fmt::Result {
-        formatter.write_str("a valid string representation of Action")
-      }
-
-      fn visit_str<E>(self, value: &str) -> Result<Action, E>
-      where
-        E: de::Error,
-      {
-        match value {
-          "Tick" => Ok(Action::Tick),
-          "Render" => Ok(Action::Render),
-          "Suspend" => Ok(Action::Suspend),
-          "Resume" => Ok(Action::Resume),
-          "Quit" => Ok(Action::Quit),
-          "Refresh" => Ok(Action::Refresh),
-          "Help" => Ok(Action::Help),
-          data if data.starts_with("Error(") => {
-            let error_msg = data.trim_start_matches("Error(").trim_end_matches(")");
-            Ok(Action::Error(error_msg.to_string()))
-          },
-          data if data.starts_with("Resize(") => {
-            let parts: Vec<&str> = data.trim_start_matches("Resize(").trim_end_matches(")").split(',').collect();
-            if parts.len() == 2 {
-              let width: u16 = parts[0].trim().parse().map_err(E::custom)?;
-              let height: u16 = parts[1].trim().parse().map_err(E::custom)?;
-              Ok(Action::Resize(width, height))
-            } else {
-              Err(E::custom(format!("Invalid Resize format: {}", value)))
-            }
-          },
-          _ => Err(E::custom(format!("Unknown Action variant: {}", value))),
-        }
-      }
-    }
-
-    deserializer.deserialize_str(ActionVisitor)
-  }
 }


### PR DESCRIPTION
Previously a manual `Deserialize` trait implementation was used but `strum::derive::Display` automates this for us